### PR TITLE
Repro: summarizeIncrementally.spec.ts test failure

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/summarizeIncrementally.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarizeIncrementally.spec.ts
@@ -96,7 +96,7 @@ function validateDDSStateInSummary(
  * These tests validate that data stores and DDSes do incremental summaries correctly, i.e., if the data
  * in it does not change, it summaries using a SummaryHandle and not a SummaryTree.
  */
-describeCompat(
+describeCompat.only(
 	"Incremental summaries for data store and DDS",
 	"1.3.7" /** equivalent to FullCompat. Currently used for testing purposes on ADO pipelines */,
 	(getTestObjectProvider, apis) => {
@@ -126,7 +126,15 @@ describeCompat(
 				this.skip();
 			}
 			const dataStore2 = await containerRuntime.createDataStore(TestDataObjectType);
-			const dataObject2 = (await dataStore2.entryPoint.get()) as ITestDataObject;
+			const dataObject2 =
+				((await dataStore2.entryPoint?.get()) as ITestDataObject) ??
+				// Added to support back compat where entryPoint is not available.
+				// Can be removed when we no longer support `^2.0.0-internal.7.0.0`
+				((
+					await (containerRuntime as any).request({
+						url: "/",
+					})
+				).value as ITestDataObject);
 			dataObject1._root.set("dataObject2", dataStore2.entryPoint);
 
 			await provider.ensureSynchronized();

--- a/packages/test/test-end-to-end-tests/src/test/summarizeIncrementally.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarizeIncrementally.spec.ts
@@ -122,9 +122,9 @@ describeCompat.only(
 
 		it("can do incremental data store summary", async function () {
 			// TODO: Re-enable after cross version compat bugs are fixed - ADO:6978
-			if (provider.type === "TestObjectProviderWithVersionedLoad") {
-				this.skip();
-			}
+			// if (provider.type === "TestObjectProviderWithVersionedLoad") {
+			// 	this.skip();
+			// }
 			const dataStore2 = await containerRuntime.createDataStore(TestDataObjectType);
 			const dataObject2 =
 				((await dataStore2.entryPoint?.get()) as ITestDataObject) ??


### PR DESCRIPTION
## Description

This PR will **not** be merged and is only to reproduce a test failure.

### Steps to repro:
1. `pnpm i && pnpm build:fast`
2. `cd packages/test/test-end-to-end-tests`
3. `pnpm test`

### Expected test failure:
```
  1) Incremental summaries for data store and DDS
       compat cross version - create with 1.3.7 + load with 2.0.0-rc.2.0.0
         can do incremental data store summary:

      AssertionError [ERR_ASSERTION]: Data store summary should be a handle
      + expected - actual

      -1
      +3
      
      at validateDataStoreStateInSummary (file:///workspaces/FluidFramework/packages/test/test-end-to-end-tests/src/test/summarizeIncrementally.spec.ts:49:9)
      at Context.<anonymous> (file:///workspaces/FluidFramework/packages/test/test-end-to-end-tests/src/test/summarizeIncrementally.spec.ts:178:4)
      at processTicksAndRejections (node:internal/process/task_queues:95:5)
```