### PR TITLE
WIP: Add version control warning mechanism

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -140,6 +140,7 @@ import {
 	tagCodeArtifacts,
 	normalizeError,
 } from "@fluidframework/telemetry-utils/internal";
+import { gte } from "semver-ts";
 import { v4 as uuid } from "uuid";
 
 import { BindBatchTracker } from "./batchTracker.js";
@@ -1038,6 +1039,11 @@ export class ContainerRuntime
 			compressionOptions.minimumBatchSizeInBytes !== Number.POSITIVE_INFINITY &&
 			compressionOptions.compressionAlgorithm === "lz4";
 
+		// minVersionForCollab enforcement only supported 2.40.0 or later is only supported in 2.40.0 and later.
+		const minVersionForCollabForDocSchema = gte(minVersionForCollab, "2.40.0")
+			? minVersionForCollab
+			: undefined;
+
 		const documentSchemaController = new DocumentsSchemaController(
 			existing,
 			protocolSequenceNumber,
@@ -1049,6 +1055,7 @@ export class ContainerRuntime
 				opGroupingEnabled: enableGroupedBatching,
 				createBlobPayloadPending,
 				disallowedVersions: [],
+				minVersionForCollab: minVersionForCollabForDocSchema,
 			},
 			(schema) => {
 				runtime.onSchemaChange(schema);


### PR DESCRIPTION
This PR is built on top of https://github.com/microsoft/FluidFramework/pull/24422 and experiments with a way to add version control warnings when a client with a version lower than minVersionForCollab tries to collaborate on an existing document (but isn't prevented due to incompatibilities by other document schema constraints).