### PR TITLE
feat(fluid-static): add "CC-1" as a new CompatibilityMode value in the declarative model

### DIFF
--- a/CrossClientCompatibility.md
+++ b/CrossClientCompatibility.md
@@ -127,6 +127,9 @@ Below is the mapping of `CompatibilityMode` values to `minVersionForCollab` at t
 | --- | --- | --- |
 | `"1"` | Supports collaboration with 1.x clients. Uses a conservative set of runtime options. | `"1.0.0"` |
 | `"2"` | Supports collaboration with 2.x clients only. Enables newer features (e.g., runtime ID compressor for SharedTree support). | `"2.0.0"` |
+| `"CC-1"` | Supports collaboration with clients at Checkpoint CC-1 (2.100.0) or newer. Enables all features available at that checkpoint. | `"2.100.0"` |
+
+> **Note:** Modes `"1"` and `"2"` are retained for backward compatibility. New integrations should prefer checkpoint-based modes (e.g., `"CC-1"`), which correspond to the compatibility checkpoints documented in [CompatibilityCheckpoints.md](./CompatibilityCheckpoints.md).
 
 #### Configuring Cross-Client Compatibility (Encapsulated Model)
 

--- a/packages/framework/fluid-static/api-report/fluid-static.alpha.api.md
+++ b/packages/framework/fluid-static/api-report/fluid-static.alpha.api.md
@@ -5,7 +5,7 @@
 ```ts
 
 // @public
-export type CompatibilityMode = "1" | "2";
+export type CompatibilityMode = "1" | "2" | "CC-1";
 
 // @public
 export type ContainerAttachProps<T = unknown> = T;

--- a/packages/framework/fluid-static/api-report/fluid-static.beta.api.md
+++ b/packages/framework/fluid-static/api-report/fluid-static.beta.api.md
@@ -5,7 +5,7 @@
 ```ts
 
 // @public
-export type CompatibilityMode = "1" | "2";
+export type CompatibilityMode = "1" | "2" | "CC-1";
 
 // @public
 export type ContainerAttachProps<T = unknown> = T;

--- a/packages/framework/fluid-static/api-report/fluid-static.legacy.beta.api.md
+++ b/packages/framework/fluid-static/api-report/fluid-static.legacy.beta.api.md
@@ -5,7 +5,7 @@
 ```ts
 
 // @public
-export type CompatibilityMode = "1" | "2";
+export type CompatibilityMode = "1" | "2" | "CC-1";
 
 // @public
 export type ContainerAttachProps<T = unknown> = T;

--- a/packages/framework/fluid-static/api-report/fluid-static.legacy.public.api.md
+++ b/packages/framework/fluid-static/api-report/fluid-static.legacy.public.api.md
@@ -5,7 +5,7 @@
 ```ts
 
 // @public
-export type CompatibilityMode = "1" | "2";
+export type CompatibilityMode = "1" | "2" | "CC-1";
 
 // @public
 export type ContainerAttachProps<T = unknown> = T;

--- a/packages/framework/fluid-static/api-report/fluid-static.public.api.md
+++ b/packages/framework/fluid-static/api-report/fluid-static.public.api.md
@@ -5,7 +5,7 @@
 ```ts
 
 // @public
-export type CompatibilityMode = "1" | "2";
+export type CompatibilityMode = "1" | "2" | "CC-1";
 
 // @public
 export type ContainerAttachProps<T = unknown> = T;

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -170,7 +170,11 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {},
+		"broken": {
+			"TypeAlias_CompatibilityMode": {
+				"backCompat": false
+			}
+		},
 		"entrypoint": "public"
 	}
 }

--- a/packages/framework/fluid-static/src/compatibilityConfiguration.ts
+++ b/packages/framework/fluid-static/src/compatibilityConfiguration.ts
@@ -26,4 +26,8 @@ export const compatibilityModeRuntimeOptions: Record<
 		// is bundled with the fluid-framework package, we need to enable it here to support SharedTree.
 		enableRuntimeIdCompressor: "on",
 	},
+	"CC-1": {
+		// CC-1 is a 2.x checkpoint, so it requires the same runtime options as mode "2".
+		enableRuntimeIdCompressor: "on",
+	},
 };

--- a/packages/framework/fluid-static/src/test/types/validateFluidStaticPrevious.generated.ts
+++ b/packages/framework/fluid-static/src/test/types/validateFluidStaticPrevious.generated.ts
@@ -141,6 +141,7 @@ declare type old_as_current_for_TypeAlias_CompatibilityMode = requireAssignableT
  * typeValidation.broken:
  * "TypeAlias_CompatibilityMode": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_TypeAlias_CompatibilityMode = requireAssignableTo<TypeOnly<current.CompatibilityMode>, TypeOnly<old.CompatibilityMode>>
 
 /*

--- a/packages/framework/fluid-static/src/types.ts
+++ b/packages/framework/fluid-static/src/types.ts
@@ -19,12 +19,28 @@ import type { ITree } from "@fluidframework/tree";
 
 /**
  * Determines the set of runtime options that Fluid Framework will use when running.
- * In "1" mode we support full interop between 2.x clients and 1.x clients,
- * while in "2" mode we only support interop between 2.x clients.
+ *
+ * @remarks
+ *
+ * Modes `"1"` and `"2"` are legacy values retained for backward compatibility.
+ * New integrations should use checkpoint-based modes such as `"CC-1"`.
+ *
+ * - `"1"` — Supports collaboration with 1.x clients. Uses a conservative set of runtime options.
+ *
+ * - `"2"` — Supports collaboration with 2.x clients only. Enables newer features
+ *   (e.g., runtime ID compressor for SharedTree support).
+ *
+ * - `"CC-1"` — Supports collaboration with clients at Compatibility Checkpoint CC-1
+ *   (release 2.100.0) or newer. Enables all features available at that checkpoint.
+ *
+ * Checkpoint modes correspond to the compatibility checkpoints documented in
+ * {@link https://github.com/microsoft/FluidFramework/blob/main/CompatibilityCheckpoints.md | CompatibilityCheckpoints.md}.
+ *
+ * @deprecated Modes `"1"` and `"2"` are deprecated. Use checkpoint modes (e.g., `"CC-1"`) instead.
  *
  * @public
  */
-export type CompatibilityMode = "1" | "2";
+export type CompatibilityMode = "1" | "2" | "CC-1";
 
 /**
  * A mapping of string identifiers to instantiated `DataObject`s or `SharedObject`s.

--- a/packages/framework/fluid-static/src/types.ts
+++ b/packages/framework/fluid-static/src/types.ts
@@ -27,16 +27,12 @@ import type { ITree } from "@fluidframework/tree";
  *
  * - `"1"` — Supports collaboration with 1.x clients. Uses a conservative set of runtime options.
  *
- * - `"2"` — Supports collaboration with 2.x clients only. Enables newer features
- *   (e.g., runtime ID compressor for SharedTree support).
+ * - `"2"` — Supports collaboration with 2.x clients only. Enables newer features (e.g., runtime ID compressor for SharedTree support).
  *
- * - `"CC-1"` — Supports collaboration with clients at Compatibility Checkpoint CC-1
- *   (release 2.100.0) or newer. Enables all features available at that checkpoint.
+ * - `"CC-1"` — Supports collaboration with clients at Compatibility Checkpoint CC-1 (release 2.100.0) or newer. Enables all features available at that checkpoint.
  *
  * Checkpoint modes correspond to the compatibility checkpoints documented in
  * {@link https://github.com/microsoft/FluidFramework/blob/main/CompatibilityCheckpoints.md | CompatibilityCheckpoints.md}.
- *
- * @deprecated Modes `"1"` and `"2"` are deprecated. Use checkpoint modes (e.g., `"CC-1"`) instead.
  *
  * @public
  */

--- a/packages/framework/fluid-static/src/utils.ts
+++ b/packages/framework/fluid-static/src/utils.ts
@@ -152,6 +152,7 @@ export function makeFluidObject<
 export const compatibilityModeToMinVersionForCollab = {
 	"1": "1.0.0",
 	"2": "2.0.0",
+	"CC-1": "2.100.0",
 } as const satisfies Record<CompatibilityMode, MinimumVersionForCollab>;
 
 /**


### PR DESCRIPTION
## Description

Implementation PR for follow-up to [Update Cross-Client Compat Policy](https://github.com/microsoft/FluidFramework/pull/27064) — "Update declarative model scenarios/documentation as necessary".

Adds `"CC-1"` as a new `CompatibilityMode` value in the declarative model, mapped to release `2.100.0` (the first compatibility checkpoint). Updates the version mapping, runtime options configuration, and `CrossClientCompatibility.md`.

A second commit cleans up CI issues introduced by the first:
- marks `TypeAlias_CompatibilityMode` as `backCompat: false` (adding a union member is not back-compat with v2.92.0's narrower type)
- removes the misapplied `@deprecated` tag (it deprecated the entire type, triggering `import-x/no-deprecated` at every internal callsite — TSDoc has no per-union-member deprecation)
- regenerates type tests and api-report files

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

Draft — superseding the empty tracking PR (#30) with the actual implementation.

AB#53800