### PR TITLE
docs: add compatibility checkpoints page to docs site

### DIFF
--- a/CompatibilityCheckpoints.md
+++ b/CompatibilityCheckpoints.md
@@ -41,3 +41,7 @@ checkpoints are designated.
 > 2. Dates and version ranges for future checkpoints are estimates and are
 >    subject to change. Exact release versions and dates will be added as each
 >    checkpoint is designated.
+
+---
+
+> This information is also available on the [Fluid Framework website](https://fluidframework.com/docs/concepts/compatibility-checkpoints).

--- a/docs/docs/concepts/compatibility-checkpoints.mdx
+++ b/docs/docs/concepts/compatibility-checkpoints.mdx
@@ -1,0 +1,36 @@
+---
+title: Compatibility Checkpoints
+sidebar_position: 5
+description: Designated checkpoint releases that define the Fluid Framework cross-client compatibility window.
+---
+
+# Compatibility Checkpoints
+
+Compatibility checkpoints are designated Fluid Framework releases that mark cross-client compatibility boundaries. They define which versions of Fluid can safely collaborate on the same document.
+
+## Schedule
+
+Checkpoints are designated on a **6-month cadence**. Any two clients whose checkpoint
+releases are within **~18 months** of each other (spanning Checkpoint N through
+Checkpoint N-3) are guaranteed to be cross-client compatible.
+
+## Checkpoints
+
+| Checkpoint | Release | Date | Compatible With |
+|------------|---------|------|-----------------|
+| CC-1 | 2.100.0 | 2026-04-27 | CC-1, all prior releases >= 2.0.0* |
+
+> **\*Note:** Since `CC-1` is the first designated checkpoint, it is
+> compatible with all prior Fluid releases >= 2.0.0. Future checkpoints will define
+> compatibility relative to other checkpoints within the 18-month window.
+
+## Learn More
+
+- [Cross-Client Compatibility Policy](https://github.com/microsoft/FluidFramework/blob/main/CrossClientCompatibility.md) — Full policy documentation
+- [Compatibility Checkpoints (source)](https://github.com/microsoft/FluidFramework/blob/main/CompatibilityCheckpoints.md) — Authoritative checkpoint list maintained in the repository
+
+:::note
+The authoritative list of compatibility checkpoints is maintained in the repository root at
+[`CompatibilityCheckpoints.md`](https://github.com/microsoft/FluidFramework/blob/main/CompatibilityCheckpoints.md).
+This page may lag behind the source; always check the repository for the latest information.
+:::

--- a/docs/docs/concepts/compatibility-checkpoints.mdx
+++ b/docs/docs/concepts/compatibility-checkpoints.mdx
@@ -10,24 +10,35 @@ Compatibility checkpoints are designated Fluid Framework releases that mark cros
 
 ## Schedule
 
-Checkpoints are designated on a **6-month cadence**. Any two clients whose checkpoint
-releases are within **~18 months** of each other (spanning Checkpoint N through
-Checkpoint N-3) are guaranteed to be cross-client compatible.
+Checkpoints are designated on a cadence of **no less than 6 months**. Any two clients
+whose checkpoint releases are within **18 months** of each other (spanning Checkpoint N
+through Checkpoint N-3) are guaranteed to be cross-client compatible.
 
 ## Checkpoints
 
-| Checkpoint | Release | Date | Compatible With |
-|------------|---------|------|-----------------|
-| CC-1 | 2.100.0 | 2026-04-27 | CC-1, all prior releases >= 2.0.0* |
+| Checkpoint | Version Range                                    | Earliest Date | Compatible Checkpoints                    |
+| ---------- | ------------------------------------------------ | ------------- | ----------------------------------------- |
+| CC-1       | `>=1.4.0 <2.0.0 \| 2.0.0-internal* \| 2.0.0-rc*` | 2024-04-09    | CC-1, CC-2, CC-3, CC-4                    |
+| CC-2       | `>=2.0.0 <2.60.0`                                | 2024-06-26    | CC-1, CC-2, CC-3, CC-4, CC-5              |
+| CC-3       | `>=2.60.0 <2.100.0`                              | 2025-09-02    | CC-1, CC-2, CC-3, CC-4, CC-5, CC-6        |
+| CC-4       | `>=2.100.0 <2.140.0` (limit TBD)                 | ~2026-04-27   | CC-1, CC-2, CC-3, CC-4, CC-5, CC-6, CC-7  |
+| CC-5 (TBD) | `>=2.140.0 <2.180.0`                             | ~2026-12-07   | CC-2, CC-3, CC-4, CC-5, CC-6, CC-7, CC-8  |
+| CC-6 (TBD) | `>=2.180.0 <2.220.0`                             | ~2027-07-19   | CC-3, CC-4, CC-5, CC-6, CC-7, CC-8, CC-9  |
+| CC-7 (TBD) | `>=2.220.0 <2.260.0`                             | ~2028-02-28   | CC-4, CC-5, CC-6, CC-7, CC-8, CC-9, CC-10 |
 
-> **\*Note:** Since `CC-1` is the first designated checkpoint, it is
-> compatible with all prior Fluid releases >= 2.0.0. Future checkpoints will define
-> compatibility relative to other checkpoints within the 18-month window.
+> **Notes:**
+>
+> 1. `CC-1`, `CC-2`, and `CC-3` were designated retroactively based on existing
+>    Fluid Framework releases, which is why the cadence between them is
+>    irregular. Starting with `CC-4`, checkpoints follow the standard cadence.
+> 2. Dates and version ranges for future checkpoints are estimates and are
+>    subject to change. Exact release versions and dates will be added as each
+>    checkpoint is designated.
 
 ## Learn More
 
-- [Cross-Client Compatibility Policy](https://github.com/microsoft/FluidFramework/blob/main/CrossClientCompatibility.md) — Full policy documentation
-- [Compatibility Checkpoints (source)](https://github.com/microsoft/FluidFramework/blob/main/CompatibilityCheckpoints.md) — Authoritative checkpoint list maintained in the repository
+-   [Cross-Client Compatibility Policy](https://github.com/microsoft/FluidFramework/blob/main/CrossClientCompatibility.md) — Full policy documentation
+-   [Compatibility Checkpoints (source)](https://github.com/microsoft/FluidFramework/blob/main/CompatibilityCheckpoints.md) — Authoritative checkpoint list maintained in the repository
 
 :::note
 The authoritative list of compatibility checkpoints is maintained in the repository root at


### PR DESCRIPTION
## Description

Implementation PR for follow-up to [Update Cross-Client Compat Policy](https://github.com/microsoft/FluidFramework/pull/27064) — "Consider duplicating compat checkpoints documentation in another location".

Duplicates the compatibility checkpoints documentation onto fluidframework.com under Concepts, and adds a cross-reference from the repo-root `CompatibilityCheckpoints.md` to the docs site page.

A follow-up commit syncs the docs-site mdx with the authoritative source table (CC-1 → CC-7) — the original commit was authored before the parent PR's final 7-row table was merged — and applies prettier formatting required by the docs site build.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

Draft — superseding the empty tracking PR (#34) with the actual implementation.

AB#53800