### PR TITLE
feat(fluid-static): support minVersionForCollab in declarative model

### DIFF
--- a/packages/framework/fluid-static/api-report/fluid-static.alpha.api.md
+++ b/packages/framework/fluid-static/api-report/fluid-static.alpha.api.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-// @public
+// @public @deprecated
 export type CompatibilityMode = "1" | "2";
 
 // @public

--- a/packages/framework/fluid-static/api-report/fluid-static.beta.api.md
+++ b/packages/framework/fluid-static/api-report/fluid-static.beta.api.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-// @public
+// @public @deprecated
 export type CompatibilityMode = "1" | "2";
 
 // @public

--- a/packages/framework/fluid-static/api-report/fluid-static.legacy.beta.api.md
+++ b/packages/framework/fluid-static/api-report/fluid-static.legacy.beta.api.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-// @public
+// @public @deprecated
 export type CompatibilityMode = "1" | "2";
 
 // @public
@@ -19,7 +19,8 @@ export interface ContainerSchema {
 // @beta @legacy
 export function createTreeContainerRuntimeFactory(props: {
     readonly schema: TreeContainerSchema;
-    readonly compatibilityMode: CompatibilityMode;
+    readonly compatibilityMode?: CompatibilityMode;
+    readonly minVersionForCollab?: MinimumVersionForCollab;
     readonly rootDataStoreRegistry?: IFluidDataStoreRegistry;
     readonly runtimeOptionOverrides?: Partial<IContainerRuntimeOptions>;
     readonly minVersionForCollabOverride?: MinimumVersionForCollab;

--- a/packages/framework/fluid-static/api-report/fluid-static.legacy.public.api.md
+++ b/packages/framework/fluid-static/api-report/fluid-static.legacy.public.api.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-// @public
+// @public @deprecated
 export type CompatibilityMode = "1" | "2";
 
 // @public

--- a/packages/framework/fluid-static/api-report/fluid-static.public.api.md
+++ b/packages/framework/fluid-static/api-report/fluid-static.public.api.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-// @public
+// @public @deprecated
 export type CompatibilityMode = "1" | "2";
 
 // @public

--- a/packages/framework/fluid-static/src/compatibilityConfiguration.ts
+++ b/packages/framework/fluid-static/src/compatibilityConfiguration.ts
@@ -5,6 +5,7 @@
 
 import type { IContainerRuntimeOptionsInternal } from "@fluidframework/container-runtime/internal";
 
+// eslint-disable-next-line import-x/no-deprecated
 import type { CompatibilityMode } from "./types.js";
 
 /**
@@ -16,6 +17,7 @@ import type { CompatibilityMode } from "./types.js";
  * from the default values (i.e. `enableRuntimeIdCompressor` below).
  */
 export const compatibilityModeRuntimeOptions: Record<
+	// eslint-disable-next-line import-x/no-deprecated
 	CompatibilityMode,
 	IContainerRuntimeOptionsInternal
 > = {

--- a/packages/framework/fluid-static/src/rootDataObject.ts
+++ b/packages/framework/fluid-static/src/rootDataObject.ts
@@ -31,8 +31,8 @@ import type {
 } from "@fluidframework/runtime-definitions/internal";
 import type { SharedObjectKind } from "@fluidframework/shared-object-base/internal";
 
-import { compatibilityModeRuntimeOptions } from "./compatibilityConfiguration.js";
 import type {
+	// eslint-disable-next-line import-x/no-deprecated
 	CompatibilityMode,
 	ContainerSchema,
 	IRootDataObject,
@@ -42,13 +42,13 @@ import type {
 	LoadableObjectRecord,
 } from "./types.js";
 import {
-	compatibilityModeToMinVersionForCollab,
 	createDataObject,
 	createSharedObject,
 	isDataObjectKind,
 	isSharedObjectKind,
 	makeFluidObject,
 	parseDataObjectsFromSharedObjects,
+	resolveMinVersionAndRuntimeOptions,
 } from "./utils.js";
 
 /**
@@ -188,17 +188,27 @@ async function provideEntryPoint(
  * The root data object's registry and initial objects are configured based on the provided
  * schema (and optionally, data store registry).
  *
+ * Exactly one of `compatibilityMode` or `minVersionForCollab` must be provided.
+ * Prefer `minVersionForCollab`; `compatibilityMode` and `minVersionForCollabOverride` exist for backward compatibility.
+ *
  * @internal
  */
+// eslint-disable-next-line import-x/no-deprecated
 export function createDOProviderContainerRuntimeFactory(props: {
 	/**
 	 * The schema for the container.
 	 */
 	schema: ContainerSchema;
 	/**
-	 * See {@link CompatibilityMode} and compatibilityModeRuntimeOptions for more details.
+	 * @deprecated Use {@link createDOProviderContainerRuntimeFactory.minVersionForCollab | minVersionForCollab} instead.
 	 */
-	compatibilityMode: CompatibilityMode;
+	// eslint-disable-next-line import-x/no-deprecated
+	compatibilityMode?: CompatibilityMode;
+	/**
+	 * Minimum Fluid Framework version required for collaboration on the document.
+	 * Replaces `compatibilityMode`; aligns the declarative model with the encapsulated model's `minVersionForCollab` configuration.
+	 */
+	minVersionForCollab?: MinimumVersionForCollab;
 	/**
 	 * Optional registry of data stores to pass to the DataObject factory.
 	 * If not provided, one will be created based on the schema.
@@ -206,34 +216,37 @@ export function createDOProviderContainerRuntimeFactory(props: {
 	rootDataStoreRegistry?: IFluidDataStoreRegistry;
 	/**
 	 * Optional overrides for the container runtime options.
-	 * If not provided, only the default options for the given compatibilityMode will be used.
 	 */
 	runtimeOptionOverrides?: Partial<IContainerRuntimeOptions>;
 	/**
-	 * Optional override for minimum version for collab.
-	 * If not provided, the default for the given compatibilityMode will be used.
-	 * @remarks
-	 * This is useful when runtime options are overridden and change the minimum version for collab.
+	 * @deprecated Use `minVersionForCollab` instead. When set, behaves identically to passing `minVersionForCollab` directly.
 	 */
 	minVersionForCollabOverride?: MinimumVersionForCollab;
 }): IRuntimeFactory {
 	const {
 		compatibilityMode,
+		minVersionForCollab,
 		minVersionForCollabOverride,
 		rootDataStoreRegistry,
 		runtimeOptionOverrides,
 		schema,
 	} = props;
+
+	const { minVersionForCollab: resolvedMinVersion, runtimeOptions: baseRuntimeOptions } =
+		resolveMinVersionAndRuntimeOptions({
+			compatibilityMode,
+			minVersionForCollab: minVersionForCollab ?? minVersionForCollabOverride,
+		});
+
 	const [registryEntries, sharedObjects] = parseDataObjectsFromSharedObjects(schema);
 	const registry = rootDataStoreRegistry ?? new FluidDataStoreRegistry(registryEntries);
 
 	return new DOProviderContainerRuntimeFactory(
 		schema,
-		compatibilityMode,
 		new RootDataObjectFactory(sharedObjects, registry),
 		{
-			runtimeOptions: runtimeOptionOverrides,
-			minVersionForCollab: minVersionForCollabOverride,
+			runtimeOptions: { ...baseRuntimeOptions, ...runtimeOptionOverrides },
+			minVersionForCollab: resolvedMinVersion,
 		},
 	);
 }
@@ -263,31 +276,25 @@ class DOProviderContainerRuntimeFactory extends BaseContainerRuntimeFactory {
 	 * since it can take care of constructing the root data object factory based on the schema.
 	 *
 	 * @param schema - The schema for the container
-	 * @param compatibilityMode - Compatibility mode
 	 * @param rootDataObjectFactory - A factory that can construct the root data object.
+	 * @param resolvedConfig - Pre-resolved runtime options and minimum version for collab.
 	 */
 	public constructor(
 		schema: ContainerSchema,
-		compatibilityMode: CompatibilityMode,
 		rootDataObjectFactory: DataObjectFactory<
 			RootDataObject,
 			{ InitialState: RootDataObjectProps }
 		>,
-		overrides?: Partial<{
+		resolvedConfig: {
 			runtimeOptions: Partial<IContainerRuntimeOptions>;
 			minVersionForCollab: MinimumVersionForCollab;
-		}>,
+		},
 	) {
 		super({
 			registryEntries: [rootDataObjectFactory.registryEntry],
-			runtimeOptions: {
-				...compatibilityModeRuntimeOptions[compatibilityMode],
-				...overrides?.runtimeOptions,
-			},
+			runtimeOptions: resolvedConfig.runtimeOptions,
 			provideEntryPoint,
-			minVersionForCollab:
-				overrides?.minVersionForCollab ??
-				compatibilityModeToMinVersionForCollab[compatibilityMode],
+			minVersionForCollab: resolvedConfig.minVersionForCollab,
 		});
 		this.rootDataObjectFactory = rootDataObjectFactory;
 		this.initialObjects = schema.initialObjects;

--- a/packages/framework/fluid-static/src/treeRootDataObject.ts
+++ b/packages/framework/fluid-static/src/treeRootDataObject.ts
@@ -31,8 +31,8 @@ import type {
 } from "@fluidframework/runtime-definitions/internal";
 import type { SharedObjectKind } from "@fluidframework/shared-object-base/internal";
 
-import { compatibilityModeRuntimeOptions } from "./compatibilityConfiguration.js";
 import type {
+	// eslint-disable-next-line import-x/no-deprecated
 	CompatibilityMode,
 	IRootDataObject,
 	IStaticEntryPoint,
@@ -41,13 +41,13 @@ import type {
 	TreeContainerSchema,
 } from "./types.js";
 import {
-	compatibilityModeToMinVersionForCollab,
 	createDataObject,
 	createSharedObject,
 	isDataObjectKind,
 	isSharedObjectKind,
 	makeFluidObject,
 	parseDataObjectsFromSharedObjects,
+	resolveMinVersionAndRuntimeOptions,
 } from "./utils.js";
 
 /**
@@ -135,23 +135,17 @@ class TreeContainerRuntimeFactory extends BaseContainerRuntimeFactory {
 	readonly #treeRootDataObjectFactory: TreeDataObjectFactory<TreeRootDataObject>;
 
 	public constructor(
-		compatibilityMode: CompatibilityMode,
 		treeRootDataObjectFactory: TreeDataObjectFactory<TreeRootDataObject>,
-		overrides?: Partial<{
+		resolvedConfig: {
 			runtimeOptions: Partial<IContainerRuntimeOptions>;
 			minVersionForCollab: MinimumVersionForCollab;
-		}>,
+		},
 	) {
 		super({
 			registryEntries: [treeRootDataObjectFactory.registryEntry],
-			runtimeOptions: {
-				...compatibilityModeRuntimeOptions[compatibilityMode],
-				...overrides?.runtimeOptions,
-			},
+			runtimeOptions: resolvedConfig.runtimeOptions,
 			provideEntryPoint,
-			minVersionForCollab:
-				overrides?.minVersionForCollab ??
-				compatibilityModeToMinVersionForCollab[compatibilityMode],
+			minVersionForCollab: resolvedConfig.minVersionForCollab,
 		});
 		this.#treeRootDataObjectFactory = treeRootDataObjectFactory;
 	}
@@ -202,6 +196,9 @@ class TreeRootDataObjectFactory extends TreeDataObjectFactory<TreeRootDataObject
  * The root data object's registry and shared objects are configured based on the provided
  * SharedTree and optionally data store registry.
  *
+ * Exactly one of `compatibilityMode` or `minVersionForCollab` must be provided.
+ * Prefer `minVersionForCollab`; `compatibilityMode` and `minVersionForCollabOverride` exist for backward compatibility.
+ *
  * @legacy @beta
  */
 export function createTreeContainerRuntimeFactory(props: {
@@ -211,9 +208,15 @@ export function createTreeContainerRuntimeFactory(props: {
 	readonly schema: TreeContainerSchema;
 
 	/**
-	 * See {@link CompatibilityMode} and compatibilityModeRuntimeOptions for more details.
+	 * @deprecated Use `minVersionForCollab` instead.
 	 */
-	readonly compatibilityMode: CompatibilityMode;
+	// eslint-disable-next-line import-x/no-deprecated
+	readonly compatibilityMode?: CompatibilityMode;
+	/**
+	 * Minimum Fluid Framework version required for collaboration on the document.
+	 * Replaces `compatibilityMode`; aligns the declarative model with the encapsulated model's `minVersionForCollab` configuration.
+	 */
+	readonly minVersionForCollab?: MinimumVersionForCollab;
 	/**
 	 * Optional registry of data stores to pass to the DataObject factory.
 	 * If not provided, one will be created based on the schema.
@@ -221,34 +224,36 @@ export function createTreeContainerRuntimeFactory(props: {
 	readonly rootDataStoreRegistry?: IFluidDataStoreRegistry;
 	/**
 	 * Optional overrides for the container runtime options.
-	 * If not provided, only the default options for the given compatibilityMode will be used.
 	 */
 	readonly runtimeOptionOverrides?: Partial<IContainerRuntimeOptions>;
 	/**
-	 * Optional override for minimum version for collab.
-	 * If not provided, the default for the given compatibilityMode will be used.
-	 * @remarks
-	 * This is useful when runtime options are overridden and change the minimum version for collab.
+	 * @deprecated Use `minVersionForCollab` instead. When set, behaves identically to passing `minVersionForCollab` directly.
 	 */
 	readonly minVersionForCollabOverride?: MinimumVersionForCollab;
 }): IRuntimeFactory {
 	const {
 		compatibilityMode,
+		minVersionForCollab,
 		minVersionForCollabOverride,
 		rootDataStoreRegistry,
 		runtimeOptionOverrides,
 		schema,
 	} = props;
 
+	const { minVersionForCollab: resolvedMinVersion, runtimeOptions: baseRuntimeOptions } =
+		resolveMinVersionAndRuntimeOptions({
+			compatibilityMode,
+			minVersionForCollab: minVersionForCollab ?? minVersionForCollabOverride,
+		});
+
 	const [registryEntries, sharedObjects] = parseDataObjectsFromSharedObjects(schema);
 	const registry = rootDataStoreRegistry ?? new FluidDataStoreRegistry(registryEntries);
 
 	return new TreeContainerRuntimeFactory(
-		compatibilityMode,
 		new TreeRootDataObjectFactory(sharedObjects, registry),
 		{
-			runtimeOptions: runtimeOptionOverrides,
-			minVersionForCollab: minVersionForCollabOverride,
+			runtimeOptions: { ...baseRuntimeOptions, ...runtimeOptionOverrides },
+			minVersionForCollab: resolvedMinVersion,
 		},
 	);
 }

--- a/packages/framework/fluid-static/src/types.ts
+++ b/packages/framework/fluid-static/src/types.ts
@@ -22,6 +22,11 @@ import type { ITree } from "@fluidframework/tree";
  * In "1" mode we support full interop between 2.x clients and 1.x clients,
  * while in "2" mode we only support interop between 2.x clients.
  *
+ * @deprecated Pass a `MinimumVersionForCollab` semver string (e.g. `"2.0.0"`) instead.
+ * This brings the declarative model in line with the encapsulated model, which already
+ * configures cross-client compatibility via `minVersionForCollab`. The legacy mode `"1"`
+ * corresponds to `minVersionForCollab: "1.0.0"`; mode `"2"` corresponds to `"2.0.0"`.
+ *
  * @public
  */
 export type CompatibilityMode = "1" | "2";

--- a/packages/framework/fluid-static/src/utils.ts
+++ b/packages/framework/fluid-static/src/utils.ts
@@ -4,6 +4,7 @@
  */
 
 import type { DataObjectKind } from "@fluidframework/aqueduct/internal";
+import type { IContainerRuntimeOptions } from "@fluidframework/container-runtime/internal";
 import type { FluidObjectKeys, IFluidLoadable } from "@fluidframework/core-interfaces";
 import { oob } from "@fluidframework/core-utils/internal";
 import type {
@@ -19,7 +20,9 @@ import type { ISharedObjectKind } from "@fluidframework/shared-object-base/inter
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
 import { SharedTreeFactoryType } from "@fluidframework/tree/internal";
 
+import { compatibilityModeRuntimeOptions } from "./compatibilityConfiguration.js";
 import type {
+	// eslint-disable-next-line import-x/no-deprecated
 	CompatibilityMode,
 	ContainerSchema,
 	LoadableObjectKind,
@@ -152,7 +155,54 @@ export function makeFluidObject<
 export const compatibilityModeToMinVersionForCollab = {
 	"1": "1.0.0",
 	"2": "2.0.0",
+	// eslint-disable-next-line import-x/no-deprecated
 } as const satisfies Record<CompatibilityMode, MinimumVersionForCollab>;
+
+/**
+ * Resolves the {@link MinimumVersionForCollab} and base runtime options to use for a
+ * declarative-model container, given either a (deprecated) `compatibilityMode` or a
+ * direct `minVersionForCollab`. Exactly one of the two must be provided.
+ *
+ * When `minVersionForCollab` is provided, runtime options are derived from its major
+ * version: `1.x` → mode "1" defaults; otherwise → mode "2" defaults. This mirrors the
+ * mapping the legacy `compatibilityMode` switch performed.
+ *
+ * @internal
+ */
+export function resolveMinVersionAndRuntimeOptions(input: {
+	// eslint-disable-next-line import-x/no-deprecated
+	compatibilityMode?: CompatibilityMode;
+	minVersionForCollab?: MinimumVersionForCollab;
+}): {
+	minVersionForCollab: MinimumVersionForCollab;
+	runtimeOptions: IContainerRuntimeOptions;
+} {
+	const { compatibilityMode, minVersionForCollab } = input;
+	if (compatibilityMode !== undefined && minVersionForCollab !== undefined) {
+		throw new UsageError(
+			"Specify exactly one of compatibilityMode or minVersionForCollab, not both.",
+		);
+	}
+	if (compatibilityMode !== undefined) {
+		return {
+			minVersionForCollab: compatibilityModeToMinVersionForCollab[compatibilityMode],
+			runtimeOptions: compatibilityModeRuntimeOptions[compatibilityMode],
+		};
+	}
+	if (minVersionForCollab !== undefined) {
+		// MinimumVersionForCollab is constrained to `${1 | 2}.${bigint}.${bigint}` (with optional
+		// prerelease tail) by its template-literal type, so a `startsWith("1.")` check is sufficient
+		// to distinguish 1.x from 2.x without parsing semver.
+		const isLegacyMajor = minVersionForCollab.startsWith("1.");
+		return {
+			minVersionForCollab,
+			runtimeOptions: isLegacyMajor
+				? compatibilityModeRuntimeOptions["1"]
+				: compatibilityModeRuntimeOptions["2"],
+		};
+	}
+	throw new UsageError("Must specify either compatibilityMode or minVersionForCollab.");
+}
 
 /**
  * Determines if the provided schema is a valid tree-based container schema.

--- a/packages/service-clients/azure-client/api-report/azure-client.beta.api.md
+++ b/packages/service-clients/azure-client/api-report/azure-client.beta.api.md
@@ -7,15 +7,32 @@
 // @public
 export class AzureClient {
     constructor(properties: AzureClientProps);
+    // @beta
+    createContainer<const TContainerSchema extends ContainerSchema>(containerSchema: TContainerSchema, minVersionForCollab: MinimumVersionForCollab): Promise<{
+        container: IFluidContainer<TContainerSchema>;
+        services: AzureContainerServices;
+    }>;
+    // @deprecated (undocumented)
     createContainer<const TContainerSchema extends ContainerSchema>(containerSchema: TContainerSchema, compatibilityMode: CompatibilityMode): Promise<{
         container: IFluidContainer<TContainerSchema>;
         services: AzureContainerServices;
     }>;
+    // @beta
+    getContainer<TContainerSchema extends ContainerSchema>(id: string, containerSchema: TContainerSchema, minVersionForCollab: MinimumVersionForCollab): Promise<{
+        container: IFluidContainer<TContainerSchema>;
+        services: AzureContainerServices;
+    }>;
+    // @deprecated (undocumented)
     getContainer<TContainerSchema extends ContainerSchema>(id: string, containerSchema: TContainerSchema, compatibilityMode: CompatibilityMode): Promise<{
         container: IFluidContainer<TContainerSchema>;
         services: AzureContainerServices;
     }>;
     getContainerVersions(id: string, options?: AzureGetVersionsOptions): Promise<AzureContainerVersion[]>;
+    // @beta
+    viewContainerVersion<TContainerSchema extends ContainerSchema>(id: string, containerSchema: TContainerSchema, version: AzureContainerVersion, minVersionForCollab: MinimumVersionForCollab): Promise<{
+        container: IFluidContainer<TContainerSchema>;
+    }>;
+    // @deprecated (undocumented)
     viewContainerVersion<TContainerSchema extends ContainerSchema>(id: string, containerSchema: TContainerSchema, version: AzureContainerVersion, compatibilityMode: CompatibilityMode): Promise<{
         container: IFluidContainer<TContainerSchema>;
     }>;
@@ -73,7 +90,7 @@ export interface AzureRemoteConnectionConfig extends AzureConnectionConfig {
     type: "remote";
 }
 
-// @public
+// @public @deprecated
 export type CompatibilityMode = "1" | "2";
 
 // @public

--- a/packages/service-clients/azure-client/api-report/azure-client.legacy.beta.api.md
+++ b/packages/service-clients/azure-client/api-report/azure-client.legacy.beta.api.md
@@ -7,15 +7,32 @@
 // @public
 export class AzureClient {
     constructor(properties: AzureClientProps);
+    // @beta
+    createContainer<const TContainerSchema extends ContainerSchema>(containerSchema: TContainerSchema, minVersionForCollab: MinimumVersionForCollab): Promise<{
+        container: IFluidContainer<TContainerSchema>;
+        services: AzureContainerServices;
+    }>;
+    // @deprecated (undocumented)
     createContainer<const TContainerSchema extends ContainerSchema>(containerSchema: TContainerSchema, compatibilityMode: CompatibilityMode): Promise<{
         container: IFluidContainer<TContainerSchema>;
         services: AzureContainerServices;
     }>;
+    // @beta
+    getContainer<TContainerSchema extends ContainerSchema>(id: string, containerSchema: TContainerSchema, minVersionForCollab: MinimumVersionForCollab): Promise<{
+        container: IFluidContainer<TContainerSchema>;
+        services: AzureContainerServices;
+    }>;
+    // @deprecated (undocumented)
     getContainer<TContainerSchema extends ContainerSchema>(id: string, containerSchema: TContainerSchema, compatibilityMode: CompatibilityMode): Promise<{
         container: IFluidContainer<TContainerSchema>;
         services: AzureContainerServices;
     }>;
     getContainerVersions(id: string, options?: AzureGetVersionsOptions): Promise<AzureContainerVersion[]>;
+    // @beta
+    viewContainerVersion<TContainerSchema extends ContainerSchema>(id: string, containerSchema: TContainerSchema, version: AzureContainerVersion, minVersionForCollab: MinimumVersionForCollab): Promise<{
+        container: IFluidContainer<TContainerSchema>;
+    }>;
+    // @deprecated (undocumented)
     viewContainerVersion<TContainerSchema extends ContainerSchema>(id: string, containerSchema: TContainerSchema, version: AzureContainerVersion, compatibilityMode: CompatibilityMode): Promise<{
         container: IFluidContainer<TContainerSchema>;
     }>;
@@ -73,7 +90,7 @@ export interface AzureRemoteConnectionConfig extends AzureConnectionConfig {
     type: "remote";
 }
 
-// @public
+// @public @deprecated
 export type CompatibilityMode = "1" | "2";
 
 // @public

--- a/packages/service-clients/azure-client/api-report/azure-client.legacy.public.api.md
+++ b/packages/service-clients/azure-client/api-report/azure-client.legacy.public.api.md
@@ -7,15 +7,18 @@
 // @public
 export class AzureClient {
     constructor(properties: AzureClientProps);
+    // @deprecated (undocumented)
     createContainer<const TContainerSchema extends ContainerSchema>(containerSchema: TContainerSchema, compatibilityMode: CompatibilityMode): Promise<{
         container: IFluidContainer<TContainerSchema>;
         services: AzureContainerServices;
     }>;
+    // @deprecated (undocumented)
     getContainer<TContainerSchema extends ContainerSchema>(id: string, containerSchema: TContainerSchema, compatibilityMode: CompatibilityMode): Promise<{
         container: IFluidContainer<TContainerSchema>;
         services: AzureContainerServices;
     }>;
     getContainerVersions(id: string, options?: AzureGetVersionsOptions): Promise<AzureContainerVersion[]>;
+    // @deprecated (undocumented)
     viewContainerVersion<TContainerSchema extends ContainerSchema>(id: string, containerSchema: TContainerSchema, version: AzureContainerVersion, compatibilityMode: CompatibilityMode): Promise<{
         container: IFluidContainer<TContainerSchema>;
     }>;
@@ -73,7 +76,7 @@ export interface AzureRemoteConnectionConfig extends AzureConnectionConfig {
     type: "remote";
 }
 
-// @public
+// @public @deprecated
 export type CompatibilityMode = "1" | "2";
 
 // @public

--- a/packages/service-clients/azure-client/api-report/azure-client.public.api.md
+++ b/packages/service-clients/azure-client/api-report/azure-client.public.api.md
@@ -7,15 +7,18 @@
 // @public
 export class AzureClient {
     constructor(properties: AzureClientProps);
+    // @deprecated (undocumented)
     createContainer<const TContainerSchema extends ContainerSchema>(containerSchema: TContainerSchema, compatibilityMode: CompatibilityMode): Promise<{
         container: IFluidContainer<TContainerSchema>;
         services: AzureContainerServices;
     }>;
+    // @deprecated (undocumented)
     getContainer<TContainerSchema extends ContainerSchema>(id: string, containerSchema: TContainerSchema, compatibilityMode: CompatibilityMode): Promise<{
         container: IFluidContainer<TContainerSchema>;
         services: AzureContainerServices;
     }>;
     getContainerVersions(id: string, options?: AzureGetVersionsOptions): Promise<AzureContainerVersion[]>;
+    // @deprecated (undocumented)
     viewContainerVersion<TContainerSchema extends ContainerSchema>(id: string, containerSchema: TContainerSchema, version: AzureContainerVersion, compatibilityMode: CompatibilityMode): Promise<{
         container: IFluidContainer<TContainerSchema>;
     }>;
@@ -73,7 +76,7 @@ export interface AzureRemoteConnectionConfig extends AzureConnectionConfig {
     type: "remote";
 }
 
-// @public
+// @public @deprecated
 export type CompatibilityMode = "1" | "2";
 
 // @public

--- a/packages/service-clients/azure-client/package.json
+++ b/packages/service-clients/azure-client/package.json
@@ -98,6 +98,7 @@
 		"@fluidframework/driver-utils": "workspace:~",
 		"@fluidframework/fluid-static": "workspace:~",
 		"@fluidframework/routerlicious-driver": "workspace:~",
+		"@fluidframework/runtime-definitions": "workspace:~",
 		"@fluidframework/telemetry-utils": "workspace:~"
 	},
 	"devDependencies": {

--- a/packages/service-clients/azure-client/src/AzureClient.ts
+++ b/packages/service-clients/azure-client/src/AzureClient.ts
@@ -29,6 +29,7 @@ import { applyStorageCompression } from "@fluidframework/driver-utils/internal";
 import type {
 	ContainerSchema,
 	IFluidContainer,
+	// eslint-disable-next-line import-x/no-deprecated
 	CompatibilityMode,
 } from "@fluidframework/fluid-static";
 import {
@@ -37,6 +38,7 @@ import {
 	createServiceAudience,
 } from "@fluidframework/fluid-static/internal";
 import { RouterliciousDocumentServiceFactory } from "@fluidframework/routerlicious-driver/internal";
+import type { MinimumVersionForCollab } from "@fluidframework/runtime-definitions/internal";
 import { wrapConfigProviderWithDefaults } from "@fluidframework/telemetry-utils/internal";
 
 import { createAzureAudienceMember } from "./AzureAudience.js";
@@ -98,9 +100,12 @@ export class AzureClient {
 	private readonly createContainerRuntimeFactory?: ({
 		schema,
 		compatibilityMode,
+		minVersionForCollab,
 	}: {
 		schema: ContainerSchema;
-		compatibilityMode: CompatibilityMode;
+		// eslint-disable-next-line import-x/no-deprecated
+		compatibilityMode?: CompatibilityMode;
+		minVersionForCollab?: MinimumVersionForCollab;
 	}) => IRuntimeFactory;
 
 	/**
@@ -138,17 +143,41 @@ export class AzureClient {
 	 * @typeparam TContainerSchema - Used to infer the the type of 'initialObjects' in the returned container.
 	 * (normally not explicitly specified.)
 	 * @param containerSchema - Container schema for the new container.
-	 * @param compatibilityMode - Compatibility mode the container should run in.
+	 * @param minVersionForCollab - Minimum Fluid Framework version required for collaboration on the document.
 	 * @returns New detached container instance along with associated services.
+	 *
+	 * @beta
+	 */
+	// The class is @public but this overload references the @beta MinimumVersionForCollab type;
+	// the @beta tag here is intentional and required by api-extractor (ae-incompatible-release-tags).
+	// eslint-disable-next-line @fluid-internal/fluid/no-member-release-tags
+	public async createContainer<const TContainerSchema extends ContainerSchema>(
+		containerSchema: TContainerSchema,
+		minVersionForCollab: MinimumVersionForCollab,
+	): Promise<{
+		container: IFluidContainer<TContainerSchema>;
+		services: AzureContainerServices;
+	}>;
+	/**
+	 * @deprecated Pass a `MinimumVersionForCollab` semver string (e.g. `"2.0.0"`) instead.
 	 */
 	public async createContainer<const TContainerSchema extends ContainerSchema>(
 		containerSchema: TContainerSchema,
+		// eslint-disable-next-line import-x/no-deprecated
 		compatibilityMode: CompatibilityMode,
 	): Promise<{
 		container: IFluidContainer<TContainerSchema>;
 		services: AzureContainerServices;
+	}>;
+	public async createContainer<const TContainerSchema extends ContainerSchema>(
+		containerSchema: TContainerSchema,
+		// eslint-disable-next-line import-x/no-deprecated
+		compatConfig: CompatibilityMode | MinimumVersionForCollab,
+	): Promise<{
+		container: IFluidContainer<TContainerSchema>;
+		services: AzureContainerServices;
 	}> {
-		const loaderProps = this.getLoaderProps(containerSchema, compatibilityMode);
+		const loaderProps = this.getLoaderProps(containerSchema, compatConfig);
 
 		const container = await createDetachedContainer({
 			...loaderProps,
@@ -172,18 +201,42 @@ export class AzureClient {
 	 * (normally not explicitly specified.)
 	 * @param id - Unique ID of the container in Azure Fluid Relay.
 	 * @param containerSchema - Container schema used to access data objects in the container.
-	 * @param compatibilityMode - Compatibility mode the container should run in.
+	 * @param minVersionForCollab - Minimum Fluid Framework version required for collaboration on the document.
 	 * @returns Existing container instance along with associated services.
+	 *
+	 * @beta
+	 */
+	// eslint-disable-next-line @fluid-internal/fluid/no-member-release-tags
+	public async getContainer<TContainerSchema extends ContainerSchema>(
+		id: string,
+		containerSchema: TContainerSchema,
+		minVersionForCollab: MinimumVersionForCollab,
+	): Promise<{
+		container: IFluidContainer<TContainerSchema>;
+		services: AzureContainerServices;
+	}>;
+	/**
+	 * @deprecated Pass a `MinimumVersionForCollab` semver string (e.g. `"2.0.0"`) instead.
 	 */
 	public async getContainer<TContainerSchema extends ContainerSchema>(
 		id: string,
 		containerSchema: TContainerSchema,
+		// eslint-disable-next-line import-x/no-deprecated
 		compatibilityMode: CompatibilityMode,
 	): Promise<{
 		container: IFluidContainer<TContainerSchema>;
 		services: AzureContainerServices;
+	}>;
+	public async getContainer<TContainerSchema extends ContainerSchema>(
+		id: string,
+		containerSchema: TContainerSchema,
+		// eslint-disable-next-line import-x/no-deprecated
+		compatConfig: CompatibilityMode | MinimumVersionForCollab,
+	): Promise<{
+		container: IFluidContainer<TContainerSchema>;
+		services: AzureContainerServices;
 	}> {
-		const loaderProps = this.getLoaderProps(containerSchema, compatibilityMode);
+		const loaderProps = this.getLoaderProps(containerSchema, compatConfig);
 		const url = new URL(this.connectionConfig.endpoint);
 		url.searchParams.append("storage", encodeURIComponent(this.connectionConfig.endpoint));
 		url.searchParams.append(
@@ -210,18 +263,42 @@ export class AzureClient {
 	 * @param id - Unique ID of the source container in Azure Fluid Relay.
 	 * @param containerSchema - Container schema used to access data objects in the container.
 	 * @param version - Unique version of the source container in Azure Fluid Relay.
-	 * @param compatibilityMode - Compatibility mode the container should run in.
+	 * @param minVersionForCollab - Minimum Fluid Framework version required for collaboration on the document.
 	 * @returns Loaded container instance at the specified version.
+	 *
+	 * @beta
+	 */
+	// eslint-disable-next-line @fluid-internal/fluid/no-member-release-tags
+	public async viewContainerVersion<TContainerSchema extends ContainerSchema>(
+		id: string,
+		containerSchema: TContainerSchema,
+		version: AzureContainerVersion,
+		minVersionForCollab: MinimumVersionForCollab,
+	): Promise<{
+		container: IFluidContainer<TContainerSchema>;
+	}>;
+	/**
+	 * @deprecated Pass a `MinimumVersionForCollab` semver string (e.g. `"2.0.0"`) instead.
 	 */
 	public async viewContainerVersion<TContainerSchema extends ContainerSchema>(
 		id: string,
 		containerSchema: TContainerSchema,
 		version: AzureContainerVersion,
+		// eslint-disable-next-line import-x/no-deprecated
 		compatibilityMode: CompatibilityMode,
 	): Promise<{
 		container: IFluidContainer<TContainerSchema>;
+	}>;
+	public async viewContainerVersion<TContainerSchema extends ContainerSchema>(
+		id: string,
+		containerSchema: TContainerSchema,
+		version: AzureContainerVersion,
+		// eslint-disable-next-line import-x/no-deprecated
+		compatConfig: CompatibilityMode | MinimumVersionForCollab,
+	): Promise<{
+		container: IFluidContainer<TContainerSchema>;
 	}> {
-		const loaderProps = this.getLoaderProps(containerSchema, compatibilityMode);
+		const loaderProps = this.getLoaderProps(containerSchema, compatConfig);
 		const url = new URL(this.connectionConfig.endpoint);
 		url.searchParams.append("storage", encodeURIComponent(this.connectionConfig.endpoint));
 		url.searchParams.append(
@@ -286,17 +363,23 @@ export class AzureClient {
 
 	private getLoaderProps(
 		schema: ContainerSchema,
-		compatibilityMode: CompatibilityMode,
+		// eslint-disable-next-line import-x/no-deprecated
+		compatConfig: CompatibilityMode | MinimumVersionForCollab,
 	): ILoaderProps {
+		// MinimumVersionForCollab strings always contain a "."; CompatibilityMode values ("1", "2") do not.
+		const factoryArguments: {
+			schema: ContainerSchema;
+			// eslint-disable-next-line import-x/no-deprecated
+			compatibilityMode?: CompatibilityMode;
+			minVersionForCollab?: MinimumVersionForCollab;
+		} = compatConfig.includes(".")
+			? { schema, minVersionForCollab: compatConfig as MinimumVersionForCollab }
+			: // eslint-disable-next-line import-x/no-deprecated
+				{ schema, compatibilityMode: compatConfig as CompatibilityMode };
+
 		const runtimeFactory = this.createContainerRuntimeFactory
-			? this.createContainerRuntimeFactory({
-					schema,
-					compatibilityMode,
-				})
-			: createDOProviderContainerRuntimeFactory({
-					schema,
-					compatibilityMode,
-				});
+			? this.createContainerRuntimeFactory(factoryArguments)
+			: createDOProviderContainerRuntimeFactory(factoryArguments);
 
 		const load = async (): Promise<IFluidModuleWithDetails> => {
 			return {

--- a/packages/service-clients/azure-client/src/interfaces.ts
+++ b/packages/service-clients/azure-client/src/interfaces.ts
@@ -11,12 +11,14 @@ import type {
 import type { IUser } from "@fluidframework/driver-definitions";
 import type { ICompressionStorageConfig } from "@fluidframework/driver-utils";
 import type {
+	// eslint-disable-next-line import-x/no-deprecated
 	CompatibilityMode,
 	ContainerSchema,
 	IMember,
 	IServiceAudience,
 } from "@fluidframework/fluid-static";
 import type { ITokenProvider } from "@fluidframework/routerlicious-driver";
+import type { MinimumVersionForCollab } from "@fluidframework/runtime-definitions/internal";
 
 /**
  * Props for initializing a new AzureClient instance
@@ -51,9 +53,12 @@ export interface AzureClientPropsInternal extends AzureClientProps {
 	readonly createContainerRuntimeFactory?: ({
 		schema,
 		compatibilityMode,
+		minVersionForCollab,
 	}: {
 		schema: ContainerSchema;
-		compatibilityMode: CompatibilityMode;
+		// eslint-disable-next-line import-x/no-deprecated
+		compatibilityMode?: CompatibilityMode;
+		minVersionForCollab?: MinimumVersionForCollab;
 	}) => IRuntimeFactory;
 }
 

--- a/packages/service-clients/tinylicious-client/api-report/tinylicious-client.alpha.api.md
+++ b/packages/service-clients/tinylicious-client/api-report/tinylicious-client.alpha.api.md
@@ -12,10 +12,22 @@ export type ITinyliciousAudience = IServiceAudience<TinyliciousMember>;
 // @public @sealed
 export class TinyliciousClient {
     constructor(properties?: TinyliciousClientProps);
+    // @beta
+    createContainer<TContainerSchema extends ContainerSchema>(containerSchema: TContainerSchema, minVersionForCollab: MinimumVersionForCollab): Promise<{
+        container: IFluidContainer<TContainerSchema>;
+        services: TinyliciousContainerServices;
+    }>;
+    // @deprecated (undocumented)
     createContainer<TContainerSchema extends ContainerSchema>(containerSchema: TContainerSchema, compatibilityMode: CompatibilityMode): Promise<{
         container: IFluidContainer<TContainerSchema>;
         services: TinyliciousContainerServices;
     }>;
+    // @beta
+    getContainer<TContainerSchema extends ContainerSchema>(id: string, containerSchema: TContainerSchema, minVersionForCollab: MinimumVersionForCollab): Promise<{
+        container: IFluidContainer<TContainerSchema>;
+        services: TinyliciousContainerServices;
+    }>;
+    // @deprecated (undocumented)
     getContainer<TContainerSchema extends ContainerSchema>(id: string, containerSchema: TContainerSchema, compatibilityMode: CompatibilityMode): Promise<{
         container: IFluidContainer<TContainerSchema>;
         services: TinyliciousContainerServices;

--- a/packages/service-clients/tinylicious-client/api-report/tinylicious-client.beta.api.md
+++ b/packages/service-clients/tinylicious-client/api-report/tinylicious-client.beta.api.md
@@ -12,10 +12,22 @@ export type ITinyliciousAudience = IServiceAudience<TinyliciousMember>;
 // @public @sealed
 export class TinyliciousClient {
     constructor(properties?: TinyliciousClientProps);
+    // @beta
+    createContainer<TContainerSchema extends ContainerSchema>(containerSchema: TContainerSchema, minVersionForCollab: MinimumVersionForCollab): Promise<{
+        container: IFluidContainer<TContainerSchema>;
+        services: TinyliciousContainerServices;
+    }>;
+    // @deprecated (undocumented)
     createContainer<TContainerSchema extends ContainerSchema>(containerSchema: TContainerSchema, compatibilityMode: CompatibilityMode): Promise<{
         container: IFluidContainer<TContainerSchema>;
         services: TinyliciousContainerServices;
     }>;
+    // @beta
+    getContainer<TContainerSchema extends ContainerSchema>(id: string, containerSchema: TContainerSchema, minVersionForCollab: MinimumVersionForCollab): Promise<{
+        container: IFluidContainer<TContainerSchema>;
+        services: TinyliciousContainerServices;
+    }>;
+    // @deprecated (undocumented)
     getContainer<TContainerSchema extends ContainerSchema>(id: string, containerSchema: TContainerSchema, compatibilityMode: CompatibilityMode): Promise<{
         container: IFluidContainer<TContainerSchema>;
         services: TinyliciousContainerServices;

--- a/packages/service-clients/tinylicious-client/api-report/tinylicious-client.public.api.md
+++ b/packages/service-clients/tinylicious-client/api-report/tinylicious-client.public.api.md
@@ -12,10 +12,12 @@ export type ITinyliciousAudience = IServiceAudience<TinyliciousMember>;
 // @public @sealed
 export class TinyliciousClient {
     constructor(properties?: TinyliciousClientProps);
+    // @deprecated (undocumented)
     createContainer<TContainerSchema extends ContainerSchema>(containerSchema: TContainerSchema, compatibilityMode: CompatibilityMode): Promise<{
         container: IFluidContainer<TContainerSchema>;
         services: TinyliciousContainerServices;
     }>;
+    // @deprecated (undocumented)
     getContainer<TContainerSchema extends ContainerSchema>(id: string, containerSchema: TContainerSchema, compatibilityMode: CompatibilityMode): Promise<{
         container: IFluidContainer<TContainerSchema>;
         services: TinyliciousContainerServices;

--- a/packages/service-clients/tinylicious-client/package.json
+++ b/packages/service-clients/tinylicious-client/package.json
@@ -93,6 +93,7 @@
 		"@fluidframework/fluid-static": "workspace:~",
 		"@fluidframework/map": "workspace:~",
 		"@fluidframework/routerlicious-driver": "workspace:~",
+		"@fluidframework/runtime-definitions": "workspace:~",
 		"@fluidframework/runtime-utils": "workspace:~",
 		"@fluidframework/telemetry-utils": "workspace:~",
 		"@fluidframework/tinylicious-driver": "workspace:~"

--- a/packages/service-clients/tinylicious-client/src/TinyliciousClient.ts
+++ b/packages/service-clients/tinylicious-client/src/TinyliciousClient.ts
@@ -22,6 +22,7 @@ import type {
 import type {
 	ContainerSchema,
 	IFluidContainer,
+	// eslint-disable-next-line import-x/no-deprecated
 	CompatibilityMode,
 } from "@fluidframework/fluid-static";
 import {
@@ -30,6 +31,7 @@ import {
 	createServiceAudience,
 } from "@fluidframework/fluid-static/internal";
 import { RouterliciousDocumentServiceFactory } from "@fluidframework/routerlicious-driver/internal";
+import type { MinimumVersionForCollab } from "@fluidframework/runtime-definitions/internal";
 import { wrapConfigProviderWithDefaults } from "@fluidframework/telemetry-utils/internal";
 import {
 	InsecureTinyliciousTokenProvider,
@@ -72,17 +74,39 @@ export class TinyliciousClient {
 	/**
 	 * Creates a new detached container instance in Tinylicious server.
 	 * @param containerSchema - Container schema for the new container.
-	 * @param compatibilityMode - Compatibility mode the container should run in.
+	 * @param minVersionForCollab - Minimum Fluid Framework version required for collaboration on the document.
 	 * @returns New detached container instance along with associated services.
+	 *
+	 * @beta
+	 */
+	// eslint-disable-next-line @fluid-internal/fluid/no-member-release-tags
+	public async createContainer<TContainerSchema extends ContainerSchema>(
+		containerSchema: TContainerSchema,
+		minVersionForCollab: MinimumVersionForCollab,
+	): Promise<{
+		container: IFluidContainer<TContainerSchema>;
+		services: TinyliciousContainerServices;
+	}>;
+	/**
+	 * @deprecated Pass a `MinimumVersionForCollab` semver string (e.g. `"2.0.0"`) instead.
 	 */
 	public async createContainer<TContainerSchema extends ContainerSchema>(
 		containerSchema: TContainerSchema,
+		// eslint-disable-next-line import-x/no-deprecated
 		compatibilityMode: CompatibilityMode,
 	): Promise<{
 		container: IFluidContainer<TContainerSchema>;
 		services: TinyliciousContainerServices;
+	}>;
+	public async createContainer<TContainerSchema extends ContainerSchema>(
+		containerSchema: TContainerSchema,
+		// eslint-disable-next-line import-x/no-deprecated
+		compatConfig: CompatibilityMode | MinimumVersionForCollab,
+	): Promise<{
+		container: IFluidContainer<TContainerSchema>;
+		services: TinyliciousContainerServices;
 	}> {
-		const loaderProps = this.getLoaderProps(containerSchema, compatibilityMode);
+		const loaderProps = this.getLoaderProps(containerSchema, compatConfig);
 
 		// We're not actually using the code proposal (our code loader always loads the same module
 		// regardless of the proposal), but the Container will only give us a NullRuntime if there's
@@ -123,18 +147,42 @@ export class TinyliciousClient {
 	 * Accesses the existing container given its unique ID in the tinylicious server.
 	 * @param id - Unique ID of the container.
 	 * @param containerSchema - Container schema used to access data objects in the container.
-	 * @param compatibilityMode - Compatibility mode the container should run in.
+	 * @param minVersionForCollab - Minimum Fluid Framework version required for collaboration on the document.
 	 * @returns Existing container instance along with associated services.
+	 *
+	 * @beta
+	 */
+	// eslint-disable-next-line @fluid-internal/fluid/no-member-release-tags
+	public async getContainer<TContainerSchema extends ContainerSchema>(
+		id: string,
+		containerSchema: TContainerSchema,
+		minVersionForCollab: MinimumVersionForCollab,
+	): Promise<{
+		container: IFluidContainer<TContainerSchema>;
+		services: TinyliciousContainerServices;
+	}>;
+	/**
+	 * @deprecated Pass a `MinimumVersionForCollab` semver string (e.g. `"2.0.0"`) instead.
 	 */
 	public async getContainer<TContainerSchema extends ContainerSchema>(
 		id: string,
 		containerSchema: TContainerSchema,
+		// eslint-disable-next-line import-x/no-deprecated
 		compatibilityMode: CompatibilityMode,
 	): Promise<{
 		container: IFluidContainer<TContainerSchema>;
 		services: TinyliciousContainerServices;
+	}>;
+	public async getContainer<TContainerSchema extends ContainerSchema>(
+		id: string,
+		containerSchema: TContainerSchema,
+		// eslint-disable-next-line import-x/no-deprecated
+		compatConfig: CompatibilityMode | MinimumVersionForCollab,
+	): Promise<{
+		container: IFluidContainer<TContainerSchema>;
+		services: TinyliciousContainerServices;
 	}> {
-		const loaderProps = this.getLoaderProps(containerSchema, compatibilityMode);
+		const loaderProps = this.getLoaderProps(containerSchema, compatConfig);
 		const container = await loadExistingContainer({ ...loaderProps, request: { url: id } });
 		const fluidContainer = await createFluidContainer<TContainerSchema>({
 			container,
@@ -155,12 +203,20 @@ export class TinyliciousClient {
 
 	private getLoaderProps(
 		schema: ContainerSchema,
-		compatibilityMode: CompatibilityMode,
+		// eslint-disable-next-line import-x/no-deprecated
+		compatConfig: CompatibilityMode | MinimumVersionForCollab,
 	): ILoaderProps {
-		const containerRuntimeFactory = createDOProviderContainerRuntimeFactory({
-			schema,
-			compatibilityMode,
-		});
+		// MinimumVersionForCollab strings always contain a "."; CompatibilityMode values ("1", "2") do not.
+		const containerRuntimeFactory = compatConfig.includes(".")
+			? createDOProviderContainerRuntimeFactory({
+					schema,
+					minVersionForCollab: compatConfig as MinimumVersionForCollab,
+				})
+			: createDOProviderContainerRuntimeFactory({
+					schema,
+					// eslint-disable-next-line import-x/no-deprecated
+					compatibilityMode: compatConfig as CompatibilityMode,
+				});
 		const load = async (): Promise<IFluidModuleWithDetails> => {
 			return {
 				module: { fluidExport: containerRuntimeFactory },

--- a/packages/service-clients/tinylicious-client/src/interfaces.ts
+++ b/packages/service-clients/tinylicious-client/src/interfaces.ts
@@ -64,7 +64,7 @@ export interface TinyliciousConnectionConfig {
  * Any functionality regarding how the data is handled within the FluidContainer itself (e.g., which data objects or
  * DDSes to use) will not be included here but rather on the FluidContainer class itself.
  *
- * Returned by {@link TinyliciousClient.createContainer} and {@link TinyliciousClient.getContainer} alongside the FluidContainer.
+ * Returned by `TinyliciousClient.createContainer` and `TinyliciousClient.getContainer` alongside the FluidContainer.
  *
  * @sealed
  * @public

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13736,6 +13736,9 @@ importers:
       '@fluidframework/routerlicious-driver':
         specifier: workspace:~
         version: link:../../drivers/routerlicious-driver
+      '@fluidframework/runtime-definitions':
+        specifier: workspace:~
+        version: link:../../runtime/runtime-definitions
       '@fluidframework/telemetry-utils':
         specifier: workspace:~
         version: link:../../utils/telemetry-utils
@@ -14199,6 +14202,9 @@ importers:
       '@fluidframework/routerlicious-driver':
         specifier: workspace:~
         version: link:../../drivers/routerlicious-driver
+      '@fluidframework/runtime-definitions':
+        specifier: workspace:~
+        version: link:../../runtime/runtime-definitions
       '@fluidframework/runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/runtime-utils


### PR DESCRIPTION
## Description

Brings the declarative model in line with the encapsulated model's `minVersionForCollab` configuration. Today declarative-model users (`AzureClient`, `TinyliciousClient`) configure cross-client compatibility via `CompatibilityMode = "1" | "2"`, which maps to a `minVersionForCollab` internally. The encapsulated model already lets callers pass `minVersionForCollab` directly. This PR adds that path to the declarative model and deprecates the indirection.

### Public API (`@beta` overloads on `@public` clients)

- `AzureClient.{createContainer,getContainer,viewContainerVersion}` and `TinyliciousClient.{createContainer,getContainer}` gain a new overload that accepts a `MinimumVersionForCollab` semver string in place of `CompatibilityMode`.
- The existing `CompatibilityMode` overloads remain but are marked `@deprecated`.
- Per-method release tags are required because `MinimumVersionForCollab` is `@beta` while the surrounding classes are `@public`; api-extractor's `ae-incompatible-release-tags` forces the new overloads to `@beta`. The project's `no-member-release-tags` lint rule is suppressed at those overloads with a justification comment.

### Internal factories

- `createDOProviderContainerRuntimeFactory` and `createTreeContainerRuntimeFactory` make `compatibilityMode` optional and add a `minVersionForCollab?: MinimumVersionForCollab` field.
- `minVersionForCollabOverride` is now `@deprecated` (effectively an alias for `minVersionForCollab`).
- Resolution is centralized in a new `resolveMinVersionAndRuntimeOptions` helper in `utils.ts` that derives runtime options from the major version: `1.x` → mode "1" defaults; otherwise → mode "2" defaults.

### Type

- `CompatibilityMode` is `@deprecated` at the type level. The `@remarks` block already describes the legacy values.
- Internal callsites that legitimately handle `"1"`/`"2"` (the resolver, the runtime-options map, the version-mapping table) suppress `import-x/no-deprecated` per file.

## Out of scope (follow-ups)

- **Promote `MinimumVersionForCollab` to `@public`** in `runtime-definitions`. This would let us drop the per-method `@beta` tags and the `no-member-release-tags` suppression on `AzureClient`/`TinyliciousClient`. Likely needs API Council sign-off.
- **Changeset + API Council review** for the new public surface (deprecation of `CompatibilityMode` and new `@beta` overloads).
- **`OdspClient`** intentionally not touched — it currently hardcodes `compatibilityMode: "2"` internally and exposes no compat parameter. A separate PR can add a `minVersionForCollab` option there if desired.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

- The `@beta` + `eslint-disable @fluid-internal/fluid/no-member-release-tags` pattern on the new overloads is the load-bearing design choice. If reviewers prefer to first promote `MinimumVersionForCollab` to `@public` and then add these overloads cleanly, the alternative is to revert the public-method changes and ship only the internal-factory + type-deprecation pieces in this PR.
- The `resolveMinVersionAndRuntimeOptions` helper picks runtime-options based on a `startsWith("1.")` check on the version string, relying on `MinimumVersionForCollab`'s template-literal type constraint (`${1 | 2}.${bigint}.${bigint}` ± prerelease). If the type ever broadens to accept other majors, the helper needs to widen too.

Draft — follow-up to [Update Cross-Client Compat Policy](https://github.com/microsoft/FluidFramework/pull/27064).

AB#53800